### PR TITLE
Remove unnecessary lifetime parameter

### DIFF
--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -107,7 +107,7 @@ impl<'a, A, S, S2, D, E> $trt<&'a ArrayBase<S2, E>> for ArrayBase<S, D>
 /// If their shapes disagree, `rhs` is broadcast to the shape of `self`.
 ///
 /// **Panics** if broadcasting isn’t possible.
-impl<'a, 'b, A, S, S2, D, E> $trt<&'a ArrayBase<S2, E>> for &'b ArrayBase<S, D>
+impl<'a, A, S, S2, D, E> $trt<&'a ArrayBase<S2, E>> for &'a ArrayBase<S, D>
     where A: Clone + $trt<A, Output=A>,
           S: Data<Elem=A>,
           S2: Data<Elem=A>,


### PR DESCRIPTION
Rust 1.23 fixed the original issue (#103) that required `'b` to be added. (See rust-lang/rust#32008, rust-lang/rust#45425, and rust-lang/rust#45435 for the relevant Rust issues/PRs.)