### PR TITLE
Add support for 128-bit integer scalars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 dist: trusty
 matrix:
   include:
-    - rust: 1.22.1
+    - rust: 1.26.0
       env:
        - FEATURES='test docs'
     - rust: stable

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,11 @@ provider::
 Recent Changes (ndarray)
 ------------------------
 
+- 0.12.0 (not yet released)
+
+  - Add support for 128-bit integer scalars (``i128`` and ``u128``).
+  - Minimum required Rust version is 1.26.
+
 - 0.11.2
 
   - New documentation; @jturner314 has written a large “ndarray for NumPy users”

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -39,6 +39,8 @@ impl ScalarOperand for i32 { }
 impl ScalarOperand for u32 { }
 impl ScalarOperand for i64 { }
 impl ScalarOperand for u64 { }
+impl ScalarOperand for i128 { }
+impl ScalarOperand for u128 { }
 impl ScalarOperand for isize { }
 impl ScalarOperand for usize { }
 impl ScalarOperand for f32 { }
@@ -250,6 +252,8 @@ mod arithmetic_ops {
     all_scalar_ops!(u32);
     all_scalar_ops!(i64);
     all_scalar_ops!(u64);
+    all_scalar_ops!(i128);
+    all_scalar_ops!(u128);
 
     impl_scalar_lhs_op!(bool, Commute, &, BitAnd, bitand, "bit and");
     impl_scalar_lhs_op!(bool, Commute, |, BitOr, bitor, "bit or");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //!   + Efficient floating point matrix multiplication even for very large
 //!     matrices; can optionally use BLAS to improve it further.
 //!   + See also the [`ndarray-parallel`] crate for integration with rayon.
-//! - **Requires Rust 1.22**
+//! - **Requires Rust 1.26**
 //!
 //! [`ndarray-parallel`]: https://docs.rs/ndarray-parallel
 //!


### PR DESCRIPTION
Rust 1.26 adds `i128` and `u128` primitive types.

I've added a note in the changelog about this. Should the new version be `0.11.3` or `0.12.0`?