### PR TITLE
Update ndarray-rand to rand 0.5.0

### DIFF
--- a/ndarray-rand/Cargo.toml
+++ b/ndarray-rand/Cargo.toml
@@ -12,7 +12,7 @@ description = "Constructors for randomized arrays. `rand` integration for `ndarr
 keywords = ["multidimensional", "matrix", "rand", "ndarray"]
 
 [dependencies]
-rand = "0.4.1"
+rand = "0.5.0"
 ndarray = { version = "0.11.0", path = ".." }
 
 [package.metadata.release]

--- a/ndarray-rand/README.rst
+++ b/ndarray-rand/README.rst
@@ -4,6 +4,10 @@ ndarray-rand
 Recent Changes
 --------------
 
+- 0.8.0 (not yet released)
+
+  - Require rand 0.5
+
 - 0.7.0
 
   - Require ndarray 0.11

--- a/numeric-tests/Cargo.toml
+++ b/numeric-tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 ndarray = { path = ".." }
 ndarray-rand = { path = "../ndarray-rand/" }
-rand = "0.4.1"
+rand = "0.5.0"
 
 [lib]
 test = false

--- a/numeric-tests/tests/accuracy.rs
+++ b/numeric-tests/tests/accuracy.rs
@@ -5,7 +5,8 @@ extern crate ndarray_rand;
 extern crate rand;
 
 use ndarray_rand::{RandomExt, F32};
-use rand::Rng;
+use rand::{FromEntropy, Rng};
+use rand::rngs::SmallRng;
 
 use ndarray::prelude::*;
 use ndarray::{
@@ -74,7 +75,7 @@ fn accurate_eye_f32() {
         }
     }
     // pick a few random sizes
-    let mut rng = rand::weak_rng();
+    let mut rng = SmallRng::from_entropy();
     for _ in 0..10 {
         let i = rng.gen_range(15, 512);
         let j = rng.gen_range(15, 512);
@@ -110,7 +111,7 @@ fn accurate_eye_f64() {
         }
     }
     // pick a few random sizes
-    let mut rng = rand::weak_rng();
+    let mut rng = SmallRng::from_entropy();
     for _ in 0..10 {
         let i = rng.gen_range(15, 512);
         let j = rng.gen_range(15, 512);
@@ -131,7 +132,7 @@ fn accurate_eye_f64() {
 #[test]
 fn accurate_mul_f32() {
     // pick a few random sizes
-    let mut rng = rand::weak_rng();
+    let mut rng = SmallRng::from_entropy();
     for i in 0..20 {
         let m = rng.gen_range(15, 512);
         let k = rng.gen_range(15, 512);
@@ -165,7 +166,7 @@ fn accurate_mul_f32() {
 #[test]
 fn accurate_mul_f64() {
     // pick a few random sizes
-    let mut rng = rand::weak_rng();
+    let mut rng = SmallRng::from_entropy();
     for i in 0..20 {
         let m = rng.gen_range(15, 512);
         let k = rng.gen_range(15, 512);
@@ -200,7 +201,7 @@ fn accurate_mul_f64() {
 #[test]
 fn accurate_mul_with_column_f64() {
     // pick a few random sizes
-    let mut rng = rand::weak_rng();
+    let mut rng = SmallRng::from_entropy();
     for i in 0..10 {
         let m = rng.gen_range(1, 350);
         let k = rng.gen_range(1, 350);


### PR DESCRIPTION
This PR tries to replicate the old behavior as closely as possible.

This PR removes support for `Sample` and `IndependentSample`, which are deprecated in `rand 0.5.0`, and replaces them with the new `Distribution` trait.

Fixes #455.