### PR TITLE
Bump num-traits, num-complex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ bench = false
 test = true
 
 [dependencies]
-num-traits = { version = "0.1.32", default-features = false }
-num-complex = { version = "0.1.32", default-features = false }
+num-traits = "0.2"
+num-complex = "0.2"
 rustc-serialize = { version = "0.3.20", optional = true }
 itertools = { version = "0.7.0", default-features = false }
 

--- a/blas-tests/Cargo.toml
+++ b/blas-tests/Cargo.toml
@@ -12,5 +12,5 @@ ndarray = { path = "../", features = ["blas"] }
 blas-src = { version = "0.1.2", default-features = false, features = ["openblas"] }
 openblas-src = { version = "0.5.6", default-features = false, features = ["cblas", "system"] }
 defmac = "0.1"
-num-traits = "0.1.40"
+num-traits = "0.2"
 


### PR DESCRIPTION
This is a breaking change since `num-complex` is a part of `ndarray`'s a public API