### PR TITLE
Add map_mut and map_axis_mut

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1862,7 +1862,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         -> Array<B, D::Smaller>
         where D: RemoveAxis,
               F: FnMut(ArrayViewMut1<'a, A>) -> B,
-              A: 'a + Clone,
+              A: 'a,
               S: DataMut,
     {
         let view_len = self.len_of(axis);

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1701,7 +1701,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// Return an array with the same shape as `self`.
     pub fn map_mut<'a, B, F>(&'a mut self, f: F) -> Array<B, D>
-        where F: FnMut(&mut A) -> B,
+        where F: FnMut(&'a mut A) -> B,
               A: 'a,
               S: DataMut
     {

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1706,8 +1706,8 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
               S: DataMut
     {
         let dim = self.dim.clone();
-        let strides = self.strides.clone();
         if self.is_contiguous() {
+            let strides = self.strides.clone();
             let slc = self.as_slice_memory_order_mut().unwrap();
             let v = ::iterators::to_vec_mapped(slc.iter_mut(), f);
             unsafe {

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -892,7 +892,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// **Panics** if any dimension of `chunk_size` is zero<br>
     /// (**Panics** if `D` is `IxDyn` and `chunk_size` does not match the
     /// number of array axes.)
-    pub fn exact_chunks<E>(&self, chunk_size: E) -> ExactChunks<A, D>
+    pub fn exact_chunks<E>(&self, chunk_size: E) -> ExactChunks<A, D> 
         where E: IntoDimension<Dim=D>,
     {
         exact_chunks_of(self.view(), chunk_size)
@@ -930,7 +930,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///          [6, 6, 7, 7, 8, 8, 0],
     ///          [6, 6, 7, 7, 8, 8, 0]]));
     /// ```
-    pub fn exact_chunks_mut<E>(&mut self, chunk_size: E) -> ExactChunksMut<A, D>
+    pub fn exact_chunks_mut<E>(&mut self, chunk_size: E) -> ExactChunksMut<A, D> 
         where E: IntoDimension<Dim=D>,
               S: DataMut
     {
@@ -941,13 +941,13 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// The windows are all distinct overlapping views of size `window_size`
     /// that fit into the array's shape.
-    ///
+    /// 
     /// Will yield over no elements if window size is larger
     /// than the actual array size of any dimension.
     ///
     /// The produced element is an `ArrayView<A, D>` with exactly the dimension
     /// `window_size`.
-    ///
+    /// 
     /// **Panics** if any dimension of `window_size` is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `window_size` does not match the
     /// number of array axes.)

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -892,7 +892,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// **Panics** if any dimension of `chunk_size` is zero<br>
     /// (**Panics** if `D` is `IxDyn` and `chunk_size` does not match the
     /// number of array axes.)
-    pub fn exact_chunks<E>(&self, chunk_size: E) -> ExactChunks<A, D> 
+    pub fn exact_chunks<E>(&self, chunk_size: E) -> ExactChunks<A, D>
         where E: IntoDimension<Dim=D>,
     {
         exact_chunks_of(self.view(), chunk_size)
@@ -930,7 +930,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///          [6, 6, 7, 7, 8, 8, 0],
     ///          [6, 6, 7, 7, 8, 8, 0]]));
     /// ```
-    pub fn exact_chunks_mut<E>(&mut self, chunk_size: E) -> ExactChunksMut<A, D> 
+    pub fn exact_chunks_mut<E>(&mut self, chunk_size: E) -> ExactChunksMut<A, D>
         where E: IntoDimension<Dim=D>,
               S: DataMut
     {
@@ -941,13 +941,13 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// The windows are all distinct overlapping views of size `window_size`
     /// that fit into the array's shape.
-    /// 
+    ///
     /// Will yield over no elements if window size is larger
     /// than the actual array size of any dimension.
     ///
     /// The produced element is an `ArrayView<A, D>` with exactly the dimension
     /// `window_size`.
-    /// 
+    ///
     /// **Panics** if any dimension of `window_size` is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `window_size` does not match the
     /// number of array axes.)
@@ -1694,6 +1694,34 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         }
     }
 
+    /// Call `f` on a mutable reference of each element and create a new array
+    /// with the new values.
+    ///
+    /// Elements are visited in arbitrary order.
+    ///
+    /// Return an array with the same shape as `self`.
+    pub fn map_mut<'a, B, F>(&'a mut self, f: F) -> Array<B, D>
+        where F: FnMut(&mut A) -> B,
+              A: 'a,
+              S: DataMut
+    {
+        let dim = self.dim.clone();
+        let strides = self.strides.clone();
+        if self.is_contiguous() {
+            let slc = self.as_slice_memory_order_mut().unwrap();
+            let v = ::iterators::to_vec_mapped(slc.iter_mut(), f);
+            unsafe {
+                ArrayBase::from_shape_vec_unchecked(
+                    dim.strides(strides), v)
+            }
+        } else {
+            let v = ::iterators::to_vec_mapped(self.iter_mut(), f);
+            unsafe {
+                ArrayBase::from_shape_vec_unchecked(dim, v)
+            }
+        }
+    }
+
     /// Call `f` by **v**alue on each element and create a new array
     /// with the new values.
     ///
@@ -1816,6 +1844,34 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         self.subview(axis, 0).map(|first_elt| {
             unsafe {
                 mapping(ArrayView::new_(first_elt, Ix1(view_len), Ix1(view_stride)))
+            }
+        })
+    }
+
+    /// Reduce the values along an axis into just one value, producing a new
+    /// array with one less dimension.
+    /// 1-dimensional lanes are passed as mutable references to the reducer,
+    /// allowing for side-effects.
+    ///
+    /// Elements are visited in arbitrary order.
+    ///
+    /// Return the result as an `Array`.
+    ///
+    /// **Panics** if `axis` is out of bounds.
+    pub fn map_axis_mut<'a, B, F>(&'a mut self, axis: Axis, mut mapping: F)
+        -> Array<B, D::Smaller>
+        where D: RemoveAxis,
+              F: FnMut(ArrayViewMut1<'a, A>) -> B,
+              A: 'a + Clone,
+              S: DataMut,
+    {
+        let view_len = self.len_of(axis);
+        let view_stride = self.strides.axis(axis);
+        // use the 0th subview as a map to each 1d array view extended from
+        // the 0th element.
+        self.subview_mut(axis, 0).map_mut(|first_elt: &mut A| {
+            unsafe {
+                mapping(ArrayViewMut::new_(first_elt, Ix1(view_len), Ix1(view_stride)))
             }
         })
     }

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -718,7 +718,7 @@ macro_rules! outer_iter_split_at_impl {
             {
                 assert!(index <= self.iter.len);
                 let right_ptr = if index != self.iter.len {
-                    unsafe { self.iter.offset(index) }
+                    unsafe { self.iter.offset(index) } 
                 }
                 else {
                     self.iter.ptr

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -718,7 +718,7 @@ macro_rules! outer_iter_split_at_impl {
             {
                 assert!(index <= self.iter.len);
                 let right_ptr = if index != self.iter.len {
-                    unsafe { self.iter.offset(index) } 
+                    unsafe { self.iter.offset(index) }
                 }
                 else {
                     self.iter.ptr
@@ -1211,6 +1211,30 @@ pub fn to_vec_mapped<I, F, B>(iter: I, mut f: F) -> Vec<B>
     iter.fold((), |(), elt| {
         unsafe {
             ptr::write(out_ptr, f(elt));
+            len += 1;
+            result.set_len(len);
+            out_ptr = out_ptr.offset(1);
+        }
+    });
+    debug_assert_eq!(size, result.len());
+    result
+}
+
+/// Like Iterator::collect, but only for trusted length iterators
+pub fn to_vec_mapped_mut<I, F, B>(iter: I, mut f: F) -> Vec<B>
+    where I: TrustedIterator + ExactSizeIterator,
+          F: FnMut(&mut I::Item) -> B,
+{
+    // Use an `unsafe` block to do this efficiently.
+    // We know that iter will produce exactly .size() elements,
+    // and the loop can vectorize if it's clean (without branch to grow the vector).
+    let (size, _) = iter.size_hint();
+    let mut result = Vec::with_capacity(size);
+    let mut out_ptr = result.as_mut_ptr();
+    let mut len = 0;
+    iter.fold((), |(), elt| {
+        unsafe {
+            ptr::write(out_ptr, f(&mut elt));
             len += 1;
             result.set_len(len);
             out_ptr = out_ptr.offset(1);


### PR DESCRIPTION
Following #452 I tried to implement `map_mut` and `map_axis_mut`.

There is unsafe code in multiple spots and my familiarity with the overall architecture of ndarray (and Rust in general) is still lacking, so I'd like to understand if some of my choices might be calling for disaster in disguise:
- I have implemented `TrustedIterator` for `IterMut` and `slide::IterMut` - was there any reason this was not already in place (apart from not having been needed so far)? 
- to avoid issues with the borrow checker in the else branch I have modified
```rust
if let Some(slc) = as_slice_memory_order_mut() {
    [...]
} else {
    [...]
}
```
into
```rust
if self.is_contiguous() {
    let slc = self.as_slice_memory_order_mut().unwrap();
    [...]
} else {
    [...]
}
```
which seemed reasonable looking at `as_slice_memory_order_mut` implementation:
```rust
    /// Return the array’s data as a slice if it is contiguous,
    /// return `None` otherwise.
    pub fn as_slice_memory_order_mut(&mut self) -> Option<&mut [A]>
        where S: DataMut
    {
        if self.is_contiguous() {
            self.ensure_unique();
            unsafe {
                Some(slice::from_raw_parts_mut(self.ptr, self.len()))
            }
        } else {
            None
        }
    }
```

@jturner314 @rcarson3 