### PR TITLE
Remove trailing whitespace

### DIFF
--- a/blas-tests/tests/oper.rs
+++ b/blas-tests/tests/oper.rs
@@ -260,7 +260,7 @@ fn mat_mul() {
 }
 
 // Check that matrix multiplication of contiguous matrices returns a
-// matrix with the same order 
+// matrix with the same order
 #[test]
 fn mat_mul_order() {
     let (m, n, k) = (8, 8, 8);

--- a/examples/convo.rs
+++ b/examples/convo.rs
@@ -14,7 +14,7 @@ const SHARPEN: [[f32; 3]; 3] = [[0., -1., 0.], [ -1., 5., -1.], [0., -1., 0.]];
 type Kernel3x3<A> = [[A; 3]; 3];
 
 #[inline(never)]
-fn conv_3x3<F>(a: &ArrayView2<F>, out: &mut ArrayViewMut2<F>, kernel: &Kernel3x3<F>) 
+fn conv_3x3<F>(a: &ArrayView2<F>, out: &mut ArrayViewMut2<F>, kernel: &Kernel3x3<F>)
     where F: Float,
 {
     let (n, m) = a.dim();

--- a/examples/zip_many.rs
+++ b/examples/zip_many.rs
@@ -24,7 +24,7 @@ fn main() {
 
     azip!(mut a, b, c in { *a = b + c; });
     assert_eq!(a, &b + &c);
-    
+
     // sum of each row
     let ax = Axis(0);
     let mut sums = Array::zeros(a.len_of(ax));

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -37,7 +37,7 @@ pub unsafe trait Data : Sized {
 /// Array representation trait.
 ///
 /// For an array with writable elements.
-/// 
+///
 /// ***Internal trait, see `Data`.***
 pub unsafe trait DataMut : Data {
     #[doc(hidden)]

--- a/src/dimension/conversion.rs
+++ b/src/dimension/conversion.rs
@@ -110,7 +110,7 @@ macro_rules! tuple_to_array {
                 index!(tuple_expr [self] $n)
             }
         }
-        
+
         impl IntoDimension for [Ix; $n] {
             type Dim = Dim<[Ix; $n]>;
             #[inline(always)]

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -582,7 +582,7 @@ impl Dimension for Dim<[Ix; 2]> {
             Axis(1)
         }
     }
-    
+
     #[inline]
     fn first_index(&self) -> Option<Self> {
         let m = get!(self, 0);

--- a/src/dimension/ndindex.rs
+++ b/src/dimension/ndindex.rs
@@ -57,7 +57,7 @@ unsafe impl NdIndex<Ix2> for (Ix, Ix) {
     }
     #[inline]
     fn index_unchecked(&self, strides: &Ix2) -> isize {
-        stride_offset(self.0, get!(strides, 0)) + 
+        stride_offset(self.0, get!(strides, 0)) +
         stride_offset(self.1, get!(strides, 1))
     }
 }
@@ -69,7 +69,7 @@ unsafe impl NdIndex<Ix3> for (Ix, Ix, Ix) {
 
     #[inline]
     fn index_unchecked(&self, strides: &Ix3) -> isize {
-        stride_offset(self.0, get!(strides, 0)) + 
+        stride_offset(self.0, get!(strides, 0)) +
         stride_offset(self.1, get!(strides, 1)) +
         stride_offset(self.2, get!(strides, 2))
     }
@@ -133,7 +133,7 @@ macro_rules! ndindex_with_array {
             #[inline]
             fn index_unchecked(&self, _strides: &$ix_n) -> isize {
                 $(
-                stride_offset(self[$index], get!(_strides, $index)) + 
+                stride_offset(self[$index], get!(_strides, $index)) +
                 )*
                 0
             }
@@ -155,7 +155,7 @@ macro_rules! ndindex_with_array {
                               "Attempted to index with {:?} in array with {} axes",
                               self, strides.ndim());
                 $(
-                stride_offset(get!(self, $index), get!(strides, $index)) + 
+                stride_offset(get!(self, $index), get!(strides, $index)) +
                 )*
                 0
             }
@@ -177,7 +177,7 @@ macro_rules! ndindex_with_array {
                               "Attempted to index with {:?} in array with {} axes",
                               self, strides.ndim());
                 $(
-                stride_offset(self[$index], get!(strides, $index)) + 
+                stride_offset(self[$index], get!(strides, $index)) +
                 )*
                 0
             }

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -892,7 +892,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// **Panics** if any dimension of `chunk_size` is zero<br>
     /// (**Panics** if `D` is `IxDyn` and `chunk_size` does not match the
     /// number of array axes.)
-    pub fn exact_chunks<E>(&self, chunk_size: E) -> ExactChunks<A, D> 
+    pub fn exact_chunks<E>(&self, chunk_size: E) -> ExactChunks<A, D>
         where E: IntoDimension<Dim=D>,
     {
         exact_chunks_of(self.view(), chunk_size)
@@ -930,7 +930,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///          [6, 6, 7, 7, 8, 8, 0],
     ///          [6, 6, 7, 7, 8, 8, 0]]));
     /// ```
-    pub fn exact_chunks_mut<E>(&mut self, chunk_size: E) -> ExactChunksMut<A, D> 
+    pub fn exact_chunks_mut<E>(&mut self, chunk_size: E) -> ExactChunksMut<A, D>
         where E: IntoDimension<Dim=D>,
               S: DataMut
     {
@@ -941,13 +941,13 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// The windows are all distinct overlapping views of size `window_size`
     /// that fit into the array's shape.
-    /// 
+    ///
     /// Will yield over no elements if window size is larger
     /// than the actual array size of any dimension.
     ///
     /// The produced element is an `ArrayView<A, D>` with exactly the dimension
     /// `window_size`.
-    /// 
+    ///
     /// **Panics** if any dimension of `window_size` is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `window_size` does not match the
     /// number of array axes.)

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -178,7 +178,7 @@ impl<D: Dimension + Copy> NdProducer for Indices<D> {
 
     #[inline(always)]
     fn contiguous_stride(&self) -> Self::Stride { 0 }
-    
+
     #[doc(hidden)]
     fn split_at(self, axis: Axis, index: usize) -> (Self, Self) {
         let start_a = self.start;

--- a/src/iterators/macros.rs
+++ b/src/iterators/macros.rs
@@ -36,7 +36,7 @@ macro_rules! impl_ndproducer {
         unsafe fn item(&$self_:ident, $ptr:pat) {
             $refexpr:expr
         }
-    }) => { 
+    }) => {
 impl<$($typarm)*> NdProducer for $fulltype {
     $(
         type $atyn = $atyv;
@@ -98,7 +98,7 @@ impl<$($typarm)*> NdProducer for $fulltype {
     private_impl!{}
 }
 
-expand_if!(@nonempty [$($cloneparm)*] 
+expand_if!(@nonempty [$($cloneparm)*]
     impl<$($cloneparm)*> Clone for $fulltype {
         fn clone(&self) -> Self {
             $typename {
@@ -130,8 +130,8 @@ macro_rules! impl_iterator {
         fn item(&mut $self_:ident, $elt:pat) {
             $refexpr:expr
         }
-    }) => { 
-         expand_if!(@nonempty [$($cloneparm)*] 
+    }) => {
+         expand_if!(@nonempty [$($cloneparm)*]
 
             impl<$($cloneparm)*> Clone for $fulltype {
                 fn clone(&self) -> Self {

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -718,7 +718,7 @@ macro_rules! outer_iter_split_at_impl {
             {
                 assert!(index <= self.iter.len);
                 let right_ptr = if index != self.iter.len {
-                    unsafe { self.iter.offset(index) } 
+                    unsafe { self.iter.offset(index) }
                 }
                 else {
                     self.iter.ptr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,7 +340,7 @@ pub type Ixs = isize;
 /// A *column major* (a.k.a. “f” or fortran) memory order array has
 /// columns (or, in general, the outermost axis) with contiguous elements.
 ///
-/// The logical order of any array’s elements is the row major order 
+/// The logical order of any array’s elements is the row major order
 /// (the rightmost index is varying the fastest).
 /// The iterators `.iter(), .iter_mut()` always adhere to this order, for example.
 ///
@@ -367,7 +367,7 @@ pub type Ixs = isize;
 ///
 /// These are the element iterators of arrays and they produce an element
 /// sequence in the logical order of the array, that means that the elements
-/// will be visited in the sequence that corresponds to increasing the 
+/// will be visited in the sequence that corresponds to increasing the
 /// last index first: *0, ..., 0,  0*; *0, ..., 0, 1*; *0, ...0, 2* and so on.
 ///
 /// ### `.outer_iter()` and `.axis_iter()`
@@ -684,7 +684,7 @@ pub type RcArray<A, D> = ArrayBase<OwnedRcRepr<A>, D>;
 /// `Sync` (when allowed by the element type of the array too).
 ///
 /// [**`ArrayBase`**](struct.ArrayBase.html) is used to implement both the owned
-/// arrays and the views; see its docs for an overview of all array features.  
+/// arrays and the views; see its docs for an overview of all array features.
 ///
 /// See also:
 ///
@@ -701,7 +701,7 @@ pub type ArcArray<A, D> = ArrayBase<OwnedArcRepr<A>, D>;
 /// the dimensionality.
 ///
 /// [**`ArrayBase`**](struct.ArrayBase.html) is used to implement both the owned
-/// arrays and the views; see its docs for an overview of all array features.  
+/// arrays and the views; see its docs for an overview of all array features.
 ///
 /// See also:
 ///

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -755,21 +755,21 @@ mod blas_tests {
         assert!(blas_row_major_2d::<f32, _>(&m));
         assert!(!blas_column_major_2d::<f32, _>(&m));
     }
-    
+
     #[test]
     fn blas_row_major_2d_row_matrix() {
         let m: Array2<f32> = Array2::zeros((1, 5));
         assert!(blas_row_major_2d::<f32, _>(&m));
         assert!(blas_column_major_2d::<f32, _>(&m));
     }
-    
+
     #[test]
     fn blas_row_major_2d_column_matrix() {
         let m: Array2<f32> = Array2::zeros((5, 1));
         assert!(blas_row_major_2d::<f32, _>(&m));
         assert!(blas_column_major_2d::<f32, _>(&m));
     }
-    
+
     #[test]
     fn blas_row_major_2d_transposed_row_matrix() {
         let m: Array2<f32> = Array2::zeros((1, 5));
@@ -777,7 +777,7 @@ mod blas_tests {
         assert!(blas_row_major_2d::<f32, _>(&m_t));
         assert!(blas_column_major_2d::<f32, _>(&m_t));
     }
-    
+
     #[test]
     fn blas_row_major_2d_transposed_column_matrix() {
         let m: Array2<f32> = Array2::zeros((5, 1));

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -319,7 +319,7 @@ impl<'a, A, D: Dimension> NdProducer for ArrayView<'a, A, D>
 
     #[inline(always)]
     fn contiguous_stride(&self) -> Self::Stride { 1 }
-    
+
     #[doc(hidden)]
     fn split_at(self, axis: Axis, index: usize) -> (Self, Self) {
         self.split_at(axis, index)

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -17,7 +17,7 @@ fn formatting()
                "[[[   1]],\n [[   2]],\n [[   3]],\n [[   4]]]");
 
     let a = a.reshape((2, 2));
-    assert_eq!(format!("{}", a), 
+    assert_eq!(format!("{}", a),
                "[[1, 2],\n [3, 4]]");
     assert_eq!(format!("{}", a),
                "[[1, 2],\n [3, 4]]");

--- a/tests/into-ixdyn.rs
+++ b/tests/into-ixdyn.rs
@@ -11,6 +11,6 @@ fn test_arr0_into_dyn() {
 fn test_arr2_into_arrd_nonstandard_strides() {
     let arr = Array2::from_shape_fn((12, 34).f(), |(i, j)| i * 34 + j).into_dyn();
     let brr = ArrayD::from_shape_fn(vec![12, 34], |d| d[0] * 34 + d[1]);
-    
+
     assert!(arr == brr);
 }

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -405,7 +405,7 @@ fn mat_mul() {
 }
 
 // Check that matrix multiplication of contiguous matrices returns a
-// matrix with the same order 
+// matrix with the same order
 #[test]
 fn mat_mul_order() {
     let (m, n, k) = (8, 8, 8);

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -7,7 +7,7 @@ use ndarray::prelude::*;
 use ndarray::Zip;
 
 // Edge Cases for Windows iterator:
-// 
+//
 // - window size is 0
 //     - what is the behaviour of the standard for this situation?
 //       "Panics if size is 0."


### PR DESCRIPTION
I realize that this makes `git blame` harder to use on those lines where I'm removing whitespace, but there aren't many whitespace removals outside of comments and blank lines, so that shouldn't be a big issue.

I'd like to do a mass-reformat once `rustfmt` is stable, so whitespace removal could wait until then. However, the negative impact of removing the trailing whitespace now is small, and it would be really nice for people like @LukeMathWalker and me who have our editors configured to automatically remove trailing whitespace.