### PR TITLE
Add support for slicing with inclusive ranges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 dist: trusty
 matrix:
   include:
-    - rust: 1.26.0
+    - rust: 1.27.0
       env:
        - FEATURES='test docs'
     - rust: stable

--- a/README.rst
+++ b/README.rst
@@ -92,9 +92,10 @@ Recent Changes (ndarray)
 
   - Add ``var_axis`` method for computing variance by @LukeMathWalker.
   - Add support for 128-bit integer scalars (``i128`` and ``u128``).
+  - Add support for slicing with inclusive ranges (``start..=end`` and ``..=end``).
   - Bump ``num-traits`` and ``num-complex`` to version ``0.2``.
   - Bump ``blas-src`` to version ``0.2``.
-  - Bump minimum required Rust version to 1.26.
+  - Bump minimum required Rust version to 1.27.
   - Additional contributors to this release: @ExpHP, @jturner314, @alexbool, @messense, @danmack, @nbro
 
 - 0.11.2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //!   + Efficient floating point matrix multiplication even for very large
 //!     matrices; can optionally use BLAS to improve it further.
 //!   + See also the [`ndarray-parallel`] crate for integration with rayon.
-//! - **Requires Rust 1.26**
+//! - **Requires Rust 1.27**
 //!
 //! [`ndarray-parallel`]: https://docs.rs/ndarray-parallel
 //!

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -82,6 +82,14 @@ fn test_slice()
     assert!(vi.iter().zip(A.iter()).all(|(a, b)| a == b));
 }
 
+#[test]
+fn test_slice_inclusive_range() {
+    let arr = array![[1, 2, 3], [4, 5, 6]];
+    assert_eq!(arr.slice(s![1..=1, 1..=2]), array![[5, 6]]);
+    assert_eq!(arr.slice(s![1..=-1, -2..=2;-1]), array![[6, 5]]);
+    assert_eq!(arr.slice(s![0..=-1, 0..=2;2]), array![[1, 3], [4, 6]]);
+}
+
 /// Test that the compiler can infer a type for a sliced array from the
 /// arguments to `s![]`.
 ///


### PR DESCRIPTION
Rust 1.26 added support for inclusive ranges, which can be created with syntax `start..=end` or `..=end`.

The behavior of this implementation is a little weird in the rare case that `range.end == ::std::isize::MAX` due to overflow, but without changing the representation of `Slice` and `SliceOrIndex`, I don't see a good way to handle that case cleanly. This shouldn't be a significant issue in practice because:

1. It's rare to have `range.end == ::std::isize::MAX`.
2. The overflow will result in a panic in debug mode, which is reasonable behavior.
3. In release mode, the overflow will result in `slice.end = 0`, which will result in a panic when slicing unless `slice.start == 0`, which will result in an empty slice. The panic is reasonable behavior. The empty slice behavior in the `slice.start == 0` case isn't ideal, but I wouldn't expect it to result in any significant problems.