### PR TITLE
Change type of end field in slices to Bound

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,7 @@ Recent Changes (ndarray)
   - Add ``map_mut`` and ``map_axis_mut`` methods (mutable variants of ``map`` and ``map_axis``) by @LukeMathWalker.
   - Add support for 128-bit integer scalars (``i128`` and ``u128``).
   - Add support for slicing with inclusive ranges (``start..=end`` and ``..=end``).
+  - Change type of ``Slice.end`` and ``SliceOrIndex::Slice.end`` from ``Option<isize>`` to ``Bound<isize>``.
   - Relax constraint on closure from ``Fn`` to ``FnMut`` for ``mapv``, ``mapv_into``, ``map_inplace`` and ``mapv_inplace``.
   - Implement ``TrustedIterator`` for ``IterMut``.
   - Bump ``num-traits`` and ``num-complex`` to version ``0.2``.

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -8,6 +8,7 @@
 
 use {Ix, Ixs};
 use error::{from_kind, ErrorKind, ShapeError};
+use std::ops::Bound;
 
 pub use self::dim::*;
 pub use self::axis::Axis;
@@ -229,14 +230,18 @@ pub fn do_slice(
     dim: &mut Ix,
     stride: &mut Ix,
     start: Ixs,
-    end: Option<Ixs>,
+    end: Bound<Ixs>,
     step: Ixs,
 ) -> isize {
     let mut offset = 0;
 
     let axis_len = *dim;
     let start = abs_index(axis_len, start);
-    let mut end = abs_index(axis_len, end.unwrap_or(axis_len as Ixs));
+    let mut end = abs_index(axis_len, match end {
+        Bound::Included(-1) | Bound::Unbounded => axis_len as Ixs,
+        Bound::Included(i) => i + 1,
+        Bound::Excluded(i) => i,
+    });
     if end < start {
         end = start;
     }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -14,6 +14,7 @@ use ndarray::{
 };
 use ndarray::indices;
 use itertools::{enumerate, zip};
+use std::ops::Bound;
 
 #[test]
 fn test_matmul_rcarray()
@@ -75,7 +76,7 @@ fn test_slice()
         *elt = i;
     }
 
-    let vi = A.slice(s![1.., ..;2, Slice::new(0, None, 2)]);
+    let vi = A.slice(s![1.., ..;2, Slice::new(0, Bound::Unbounded, 2)]);
     assert_eq!(vi.shape(), &[2, 2, 3]);
     let vi = A.slice(s![.., .., ..]);
     assert_eq!(vi.shape(), A.shape());
@@ -334,7 +335,7 @@ fn slice_oob()
 #[test]
 fn slice_axis_oob() {
     let a = RcArray::<i32, _>::zeros((3, 4));
-    let _vi = a.slice_axis(Axis(0), Slice::new(0, Some(10), 1));
+    let _vi = a.slice_axis(Axis(0), Slice::new(0, Bound::Excluded(10), 1));
 }
 
 #[should_panic]


### PR DESCRIPTION
I just noticed the [`Bound`](https://doc.rust-lang.org/std/ops/enum.Bound.html) enum in the standard library while I was reading about the new [`RangeBounds`](https://doc.rust-lang.org/std/ops/trait.RangeBounds.html) trait. I thought I'd propose switching to the `Bound` type, now that we have support for inclusive ranges (#467). There is no memory cost to doing this (since `Bound<isize>` and `Option<isize>` are the same size). This is a breaking change.

I'm pretty ambivalent about this PR, since `Option` has the benefit of being more common than `Bound` and having lots of convenient methods. It's also nice to only have to deal with exclusive end bounds after the `Slice`/`SliceOrIndex` is created. So, I'm curious to see what everyone thinks about this change.