### PR TITLE
Remove unnecessary allocation in var_axis

### DIFF
--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -177,7 +177,7 @@ impl<A, S, D> ArrayBase<S, D>
                     of the axis you are computing the variance for!")
         } else {
             let dof = count - ddof;
-            sum_sq.mapv(|s| s / dof)
+            sum_sq.mapv_into(|s| s / dof)
         }
     }
 


### PR DESCRIPTION
It's possible to use `.mapv_into()` instead of `.mapv()` in this case because the element type doesn't change. Switching to `.mapv_into()` doesn't have a noticeable impact on benchmarks, but it's worth doing anyway just to avoid the extra allocation.