### PR TITLE
Add const vs. dynamic ndim to array Debug format

### DIFF
--- a/src/arrayformat.rs
+++ b/src/arrayformat.rs
@@ -105,9 +105,13 @@ impl<'a, A: fmt::Debug, S, D: Dimension> fmt::Debug for ArrayBase<S, D>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Add extra information for Debug
-        try!(format_array(self, f, <_>::fmt));
-        try!(write!(f, " shape={:?}, strides={:?}, layout={:?}",
-                    self.shape(), self.strides(), layout=self.view().layout()));
+        format_array(self, f, <_>::fmt)?;
+        write!(f, " shape={:?}, strides={:?}, layout={:?}",
+               self.shape(), self.strides(), layout=self.view().layout())?;
+        match D::NDIM {
+            Some(ndim) => write!(f, ", const ndim={}", ndim)?,
+            None => write!(f, ", dynamic ndim={}", self.ndim())?,
+        }
         Ok(())
     }
 }

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1,7 +1,7 @@
-
 extern crate ndarray;
 
-use ndarray::{arr0, rcarr1, aview1};
+use ndarray::prelude::*;
+use ndarray::rcarr1;
 
 #[test]
 fn formatting()
@@ -34,4 +34,21 @@ fn formatting()
 
     let s = format!("{:02x}", aview1::<u8>(&[1, 0xff, 0xfe]));
     assert_eq!(s, "[01, ff, fe]");
+}
+
+#[test]
+fn debug_format() {
+    let a = Array2::<i32>::zeros((3, 4));
+    assert_eq!(
+        format!("{:?}", a),
+        "[[0, 0, 0, 0],
+ [0, 0, 0, 0],
+ [0, 0, 0, 0]] shape=[3, 4], strides=[4, 1], layout=C (0x1), const ndim=2"
+    );
+    assert_eq!(
+        format!("{:?}", a.into_dyn()),
+        "[[0, 0, 0, 0],
+ [0, 0, 0, 0],
+ [0, 0, 0, 0]] shape=[3, 4], strides=[4, 1], layout=C (0x1), dynamic ndim=2"
+    );
 }


### PR DESCRIPTION
The difference between const-dimensional and dynamic-dimensional arrays is fairly significant, so it would be useful for the debug format to include this information. See also #489 for more motivation.

This implementation produces a debug format like this for a const-dimensional array:

```
[[0, 0, 0, 0],
 [0, 0, 0, 0],
 [0, 0, 0, 0]] shape=[3, 4], strides=[4, 1], layout=C (0x1), const ndim=2
```

and like this for a dynamic-dimensional array:

```
[[0, 0, 0, 0],
 [0, 0, 0, 0],
 [0, 0, 0, 0]] shape=[3, 4], strides=[4, 1], layout=C (0x1), dynamic ndim=2
```

(Note the addition of `const ndim=2` or `dynamic ndim=2`.)

Is the term "fixed" better than "const"? I chose "const" because the number of dimensions is a compile-time constant, and Rust often uses the name "const" for this.