### PR TITLE
Remove DataOwned constraint from into_owned

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -177,10 +177,9 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     }
 
     /// Turn the array into a uniquely owned array, cloning the array elements
-    /// to unshare them if necessary.
+    /// if necessary.
     pub fn into_owned(self) -> Array<A, D>
         where A: Clone,
-              S: DataOwned,
     {
         S::into_owned(self)
     }


### PR DESCRIPTION
This is useful because it allows generalizing `.into_owned()` to `ArrayView` and `ArrayViewMut`. This means that if you want to always clone the elements, you can use `.to_owned()`, while if you want to avoid cloning elements when possible, you can use `.into_owned()`.

This is technically a breaking change if removing undocumented methods is considered breaking (since `DataOwned::into_owned` no longer exists).