### PR TITLE
Refactor and improve iterators

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -16,7 +16,6 @@ use imp_prelude::*;
 
 use arraytraits;
 use dimension;
-use iterators;
 use error::{self, ShapeError, ErrorKind};
 use dimension::IntoDimension;
 use dimension::{abs_index, axes_of, Axes, do_slice, merge_axes, stride_offset};
@@ -858,7 +857,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///                                              [[26, 27]]]));
     /// ```
     pub fn axis_chunks_iter(&self, axis: Axis, size: usize) -> AxisChunksIter<A, D> {
-        iterators::new_chunk_iter(self.view(), axis.index(), size)
+        AxisChunksIter::new(self.view(), axis, size)
     }
 
     /// Return an iterator that traverses over `axis` by chunks of `size`,
@@ -871,7 +870,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         -> AxisChunksIterMut<A, D>
         where S: DataMut
     {
-        iterators::new_chunk_iter_mut(self.view_mut(), axis.index(), size)
+        AxisChunksIterMut::new(self.view_mut(), axis, size)
     }
 
     /// Return an exact chunks producer (and iterable).

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -20,10 +20,6 @@ use iterators;
 use error::{self, ShapeError, ErrorKind};
 use dimension::IntoDimension;
 use dimension::{abs_index, axes_of, Axes, do_slice, merge_axes, stride_offset};
-use iterators::{
-    exact_chunks_of,
-    exact_chunks_mut_of,
-};
 use zip::Zip;
 
 use {
@@ -892,7 +888,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn exact_chunks<E>(&self, chunk_size: E) -> ExactChunks<A, D>
         where E: IntoDimension<Dim=D>,
     {
-        exact_chunks_of(self.view(), chunk_size)
+        ExactChunks::new(self.view(), chunk_size)
     }
 
     /// Return an exact chunks producer (and iterable).
@@ -931,7 +927,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         where E: IntoDimension<Dim=D>,
               S: DataMut
     {
-        exact_chunks_mut_of(self.view_mut(), chunk_size)
+        ExactChunksMut::new(self.view_mut(), chunk_size)
     }
 
     /// Return a window producer and iterable.

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -23,7 +23,6 @@ use dimension::{abs_index, axes_of, Axes, do_slice, merge_axes, stride_offset};
 use iterators::{
     exact_chunks_of,
     exact_chunks_mut_of,
-    windows
 };
 use zip::Zip;
 
@@ -952,7 +951,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn windows<E>(&self, window_size: E) -> Windows<A, D>
         where E: IntoDimension<Dim=D>
     {
-        windows(self.view(), window_size)
+        Windows::new(self.view(), window_size)
     }
 
     // Return (length, stride) for diagonal

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -819,7 +819,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn axis_iter(&self, axis: Axis) -> AxisIter<A, D::Smaller>
         where D: RemoveAxis,
     {
-        iterators::new_axis_iter(self.view(), axis.index())
+        AxisIter::new(self.view(), axis)
     }
 
 
@@ -834,7 +834,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         where S: DataMut,
               D: RemoveAxis,
     {
-        iterators::new_axis_iter_mut(self.view_mut(), axis.index())
+        AxisIterMut::new(self.view_mut(), axis)
     }
 
 

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -21,8 +21,6 @@ use error::{self, ShapeError, ErrorKind};
 use dimension::IntoDimension;
 use dimension::{abs_index, axes_of, Axes, do_slice, merge_axes, stride_offset};
 use iterators::{
-    new_lanes,
-    new_lanes_mut,
     exact_chunks_of,
     exact_chunks_mut_of,
     windows
@@ -676,7 +674,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn genrows(&self) -> Lanes<A, D::Smaller> {
         let mut n = self.ndim();
         if n == 0 { n += 1; }
-        new_lanes(self.view(), Axis(n - 1))
+        Lanes::new(self.view(), Axis(n - 1))
     }
 
     /// Return a producer and iterable that traverses over the *generalized*
@@ -688,7 +686,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     {
         let mut n = self.ndim();
         if n == 0 { n += 1; }
-        new_lanes_mut(self.view_mut(), Axis(n - 1))
+        LanesMut::new(self.view_mut(), Axis(n - 1))
     }
 
     /// Return a producer and iterable that traverses over the *generalized*
@@ -718,7 +716,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// }
     /// ```
     pub fn gencolumns(&self) -> Lanes<A, D::Smaller> {
-        new_lanes(self.view(), Axis(0))
+        Lanes::new(self.view(), Axis(0))
     }
 
     /// Return a producer and iterable that traverses over the *generalized*
@@ -728,7 +726,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn gencolumns_mut(&mut self) -> LanesMut<A, D::Smaller>
         where S: DataMut
     {
-        new_lanes_mut(self.view_mut(), Axis(0))
+        LanesMut::new(self.view_mut(), Axis(0))
     }
 
     /// Return a producer and iterable that traverses over all 1D lanes
@@ -760,7 +758,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// assert_eq!(inner2.into_iter().next().unwrap(), aview1(&[0, 1, 2]));
     /// ```
     pub fn lanes(&self, axis: Axis) -> Lanes<A, D::Smaller> {
-        new_lanes(self.view(), axis)
+        Lanes::new(self.view(), axis)
     }
 
     /// Return a producer and iterable that traverses over all 1D lanes
@@ -770,7 +768,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn lanes_mut(&mut self, axis: Axis) -> LanesMut<A, D::Smaller>
         where S: DataMut
     {
-        new_lanes_mut(self.view_mut(), axis)
+        LanesMut::new(self.view_mut(), axis)
     }
 
 
@@ -1595,8 +1593,8 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         // break the arrays up into their inner rows
         let n = self.ndim();
         let dim = self.raw_dim();
-        Zip::from(new_lanes_mut(self.view_mut(), Axis(n - 1)))
-            .and(new_lanes(rhs.broadcast_assume(dim), Axis(n - 1)))
+        Zip::from(LanesMut::new(self.view_mut(), Axis(n - 1)))
+            .and(Lanes::new(rhs.broadcast_assume(dim), Axis(n - 1)))
             .apply(move |s_row, r_row| {
                 Zip::from(s_row).and(r_row).apply(|a, b| f(a, b))
             });

--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -468,7 +468,7 @@ impl<'a, A, D> ArrayView<'a, A, D>
     }
 
     #[inline]
-    pub(crate) fn into_base_iter(self) -> Baseiter<'a, A, D> {
+    pub(crate) fn into_base_iter(self) -> Baseiter<A, D> {
         unsafe {
             Baseiter::new(self.ptr, self.dim, self.strides)
         }
@@ -476,7 +476,7 @@ impl<'a, A, D> ArrayView<'a, A, D>
 
     #[inline]
     pub(crate) fn into_elements_base(self) -> ElementsBase<'a, A, D> {
-        ElementsBase { inner: self.into_base_iter() }
+        ElementsBase::new(self)
     }
 
     pub(crate) fn into_iter_(self) -> Iter<'a, A, D> {
@@ -518,7 +518,7 @@ impl<'a, A, D> ArrayViewMut<'a, A, D>
     }
 
     #[inline]
-    pub(crate) fn into_base_iter(self) -> Baseiter<'a, A, D> {
+    pub(crate) fn into_base_iter(self) -> Baseiter<A, D> {
         unsafe {
             Baseiter::new(self.ptr, self.dim, self.strides)
         }
@@ -526,7 +526,7 @@ impl<'a, A, D> ArrayViewMut<'a, A, D>
 
     #[inline]
     pub(crate) fn into_elements_base(self) -> ElementsBaseMut<'a, A, D> {
-        ElementsBaseMut { inner: self.into_base_iter() }
+        ElementsBaseMut::new(self)
     }
 
     pub(crate) fn into_slice_(self) -> Result<&'a mut [A], Self> {

--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -23,8 +23,7 @@ use {
     Baseiter,
 };
 
-use iter;
-use iterators;
+use iter::{self, AxisIter, AxisIterMut};
 
 /// Methods for read-only array views.
 impl<'a, A, D> ArrayView<'a, A, D>
@@ -490,7 +489,7 @@ impl<'a, A, D> ArrayView<'a, A, D>
     pub fn into_outer_iter(self) -> iter::AxisIter<'a, A, D::Smaller>
         where D: RemoveAxis,
     {
-        iterators::new_outer_iter(self)
+        AxisIter::new(self, Axis(0))
     }
 
 }
@@ -550,7 +549,7 @@ impl<'a, A, D> ArrayViewMut<'a, A, D>
     pub fn into_outer_iter(self) -> iter::AxisIterMut<'a, A, D::Smaller>
         where D: RemoveAxis,
     {
-        iterators::new_outer_iter_mut(self)
+        AxisIterMut::new(self, Axis(0))
     }
 }
 

--- a/src/iterators/chunks.rs
+++ b/src/iterators/chunks.rs
@@ -38,26 +38,30 @@ pub struct ExactChunks<'a, A: 'a, D> {
     inner_strides: D,
 }
 
-/// **Panics** if any chunk dimension is zero<br>
-pub fn exact_chunks_of<A, D, E>(mut a: ArrayView<A, D>, chunk: E) -> ExactChunks<A, D>
-    where D: Dimension,
-          E: IntoDimension<Dim=D>,
-{
-    let chunk = chunk.into_dimension();
-    ndassert!(a.ndim() == chunk.ndim(),
-              concat!("Chunk dimension {} does not match array dimension {} ",
-                      "(with array of shape {:?})"),
-             chunk.ndim(), a.ndim(), a.shape());
-    for i in 0..a.ndim() {
-        a.dim[i] /= chunk[i];
-    }
-    let inner_strides = a.raw_strides();
-    a.strides *= &chunk;
+impl<'a, A, D: Dimension> ExactChunks<'a, A, D> {
+    /// Creates a new exact chunks producer.
+    ///
+    /// **Panics** if any chunk dimension is zero
+    pub(crate) fn new<E>(mut a: ArrayView<'a, A, D>, chunk: E) -> Self
+    where
+        E: IntoDimension<Dim = D>,
+    {
+        let chunk = chunk.into_dimension();
+        ndassert!(a.ndim() == chunk.ndim(),
+                  concat!("Chunk dimension {} does not match array dimension {} ",
+                          "(with array of shape {:?})"),
+                  chunk.ndim(), a.ndim(), a.shape());
+        for i in 0..a.ndim() {
+            a.dim[i] /= chunk[i];
+        }
+        let inner_strides = a.raw_strides();
+        a.strides *= &chunk;
 
-    ExactChunks {
-        base: a,
-        chunk: chunk,
-        inner_strides: inner_strides,
+        ExactChunks {
+            base: a,
+            chunk: chunk,
+            inner_strides: inner_strides,
+        }
     }
 }
 
@@ -117,27 +121,30 @@ pub struct ExactChunksMut<'a, A: 'a, D> {
     inner_strides: D,
 }
 
-/// **Panics** if any chunk dimension is zero<br>
-pub fn exact_chunks_mut_of<A, D, E>(mut a: ArrayViewMut<A, D>, chunk: E)
-    -> ExactChunksMut<A, D>
-    where D: Dimension,
-          E: IntoDimension<Dim=D>,
-{
-    let chunk = chunk.into_dimension();
-    ndassert!(a.ndim() == chunk.ndim(),
-              concat!("Chunk dimension {} does not match array dimension {} ",
-                      "(with array of shape {:?})"),
-             chunk.ndim(), a.ndim(), a.shape());
-    for i in 0..a.ndim() {
-        a.dim[i] /= chunk[i];
-    }
-    let inner_strides = a.raw_strides();
-    a.strides *= &chunk;
+impl<'a, A, D: Dimension> ExactChunksMut<'a, A, D> {
+    /// Creates a new exact chunks producer.
+    ///
+    /// **Panics** if any chunk dimension is zero
+    pub(crate) fn new<E>(mut a: ArrayViewMut<'a, A, D>, chunk: E) -> Self
+    where
+        E: IntoDimension<Dim = D>,
+    {
+        let chunk = chunk.into_dimension();
+        ndassert!(a.ndim() == chunk.ndim(),
+                  concat!("Chunk dimension {} does not match array dimension {} ",
+                          "(with array of shape {:?})"),
+                  chunk.ndim(), a.ndim(), a.shape());
+        for i in 0..a.ndim() {
+            a.dim[i] /= chunk[i];
+        }
+        let inner_strides = a.raw_strides();
+        a.strides *= &chunk;
 
-    ExactChunksMut {
-        base: a,
-        chunk: chunk,
-        inner_strides: inner_strides,
+        ExactChunksMut {
+            base: a,
+            chunk: chunk,
+            inner_strides: inner_strides,
+        }
     }
 }
 

--- a/src/iterators/lanes.rs
+++ b/src/iterators/lanes.rs
@@ -1,3 +1,4 @@
+use std::marker::PhantomData;
 
 use imp_prelude::*;
 use {NdProducer, Layout};
@@ -85,6 +86,7 @@ impl<'a, A, D> IntoIterator for Lanes<'a, A, D>
             iter: self.base.into_base_iter(),
             inner_len: self.inner_len,
             inner_stride: self.inner_stride,
+            life: PhantomData,
         }
     }
 }
@@ -134,6 +136,7 @@ impl<'a, A, D> IntoIterator for LanesMut<'a, A, D>
             iter: self.base.into_base_iter(),
             inner_len: self.inner_len,
             inner_stride: self.inner_stride,
+            life: PhantomData,
         }
     }
 }

--- a/src/iterators/lanes.rs
+++ b/src/iterators/lanes.rs
@@ -30,29 +30,30 @@ pub struct Lanes<'a, A: 'a, D> {
     inner_stride: Ixs,
 }
 
-
-pub fn new_lanes<A, D>(v: ArrayView<A, D>, axis: Axis)
-    -> Lanes<A, D::Smaller>
-    where D: Dimension
-{
-    let ndim = v.ndim();
-    let len;
-    let stride;
-    let iter_v;
-    if ndim == 0 {
-        len = 1;
-        stride = 1;
-        iter_v = v.try_remove_axis(Axis(0))
-    } else {
-        let i = axis.index();
-        len = v.dim[i];
-        stride = v.strides[i] as isize;
-        iter_v = v.try_remove_axis(axis)
-    }
-    Lanes {
-        inner_len: len,
-        inner_stride: stride,
-        base: iter_v,
+impl<'a, A, D: Dimension> Lanes<'a, A, D> {
+    pub(crate) fn new<Di>(v: ArrayView<'a, A, Di>, axis: Axis) -> Self
+    where
+        Di: Dimension<Smaller = D>,
+    {
+        let ndim = v.ndim();
+        let len;
+        let stride;
+        let iter_v;
+        if ndim == 0 {
+            len = 1;
+            stride = 1;
+            iter_v = v.try_remove_axis(Axis(0))
+        } else {
+            let i = axis.index();
+            len = v.dim[i];
+            stride = v.strides[i] as isize;
+            iter_v = v.try_remove_axis(axis)
+        }
+        Lanes {
+            inner_len: len,
+            inner_stride: stride,
+            base: iter_v,
+        }
     }
 }
 
@@ -96,29 +97,30 @@ pub struct LanesMut<'a, A: 'a, D> {
     inner_stride: Ixs,
 }
 
-
-pub fn new_lanes_mut<A, D>(v: ArrayViewMut<A, D>, axis: Axis)
-    -> LanesMut<A, D::Smaller>
-    where D: Dimension
-{
-    let ndim = v.ndim();
-    let len;
-    let stride;
-    let iter_v;
-    if ndim == 0 {
-        len = 1;
-        stride = 1;
-        iter_v = v.try_remove_axis(Axis(0))
-    } else {
-        let i = axis.index();
-        len = v.dim[i];
-        stride = v.strides[i] as isize;
-        iter_v = v.try_remove_axis(axis)
-    }
-    LanesMut {
-        inner_len: len,
-        inner_stride: stride,
-        base: iter_v,
+impl<'a, A, D: Dimension> LanesMut<'a, A, D> {
+    pub(crate) fn new<Di>(v: ArrayViewMut<'a, A, Di>, axis: Axis) -> Self
+    where
+        Di: Dimension<Smaller = D>,
+    {
+        let ndim = v.ndim();
+        let len;
+        let stride;
+        let iter_v;
+        if ndim == 0 {
+            len = 1;
+            stride = 1;
+            iter_v = v.try_remove_axis(Axis(0))
+        } else {
+            let i = axis.index();
+            len = v.dim[i];
+            stride = v.strides[i] as isize;
+            iter_v = v.try_remove_axis(axis)
+        }
+        LanesMut {
+            inner_len: len,
+            inner_stride: stride,
+            base: iter_v,
+        }
     }
 }
 

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -89,16 +89,6 @@ impl<'a, A, D: Dimension> Baseiter<'a, A, D> {
         unsafe { Some(self.ptr.offset(offset)) }
     }
 
-    #[inline]
-    fn next_ref(&mut self) -> Option<&'a A> {
-        unsafe { self.next().map(|p| &*p) }
-    }
-
-    #[inline]
-    fn next_ref_mut(&mut self) -> Option<&'a mut A> {
-        unsafe { self.next().map(|p| &mut *p) }
-    }
-
     fn len(&self) -> usize {
         match self.index {
             None => 0,
@@ -157,16 +147,6 @@ impl<'a, A> Baseiter<'a, A, Ix1> {
 
         unsafe { Some(self.ptr.offset(offset)) }
     }
-
-    #[inline]
-    fn next_back_ref(&mut self) -> Option<&'a A> {
-        unsafe { self.next_back().map(|p| &*p) }
-    }
-
-    #[inline]
-    fn next_back_ref_mut(&mut self) -> Option<&'a mut A> {
-        unsafe { self.next_back().map(|p| &mut *p) }
-    }
 }
 
 clone_bounds!(
@@ -195,7 +175,7 @@ impl<'a, A, D: Dimension> Iterator for ElementsBase<'a, A, D> {
     type Item = &'a A;
     #[inline]
     fn next(&mut self) -> Option<&'a A> {
-        self.inner.next_ref()
+        self.inner.next().map(|p| unsafe { &*p })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -215,7 +195,7 @@ impl<'a, A, D: Dimension> Iterator for ElementsBase<'a, A, D> {
 impl<'a, A> DoubleEndedIterator for ElementsBase<'a, A, Ix1> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a A> {
-        self.inner.next_back_ref()
+        self.inner.next_back().map(|p| unsafe { &*p })
     }
 }
 
@@ -390,9 +370,9 @@ impl<'a, A, D: Dimension> Iterator for IndexedIter<'a, A, D> {
             None => return None,
             Some(ref ix) => ix.clone(),
         };
-        match self.0.inner.next_ref() {
+        match self.0.next() {
             None => None,
-            Some(p) => Some((index.into_pattern(), p)),
+            Some(elem) => Some((index.into_pattern(), elem)),
         }
     }
 
@@ -447,7 +427,7 @@ impl<'a, A, D: Dimension> Iterator for ElementsBaseMut<'a, A, D> {
     type Item = &'a mut A;
     #[inline]
     fn next(&mut self) -> Option<&'a mut A> {
-        self.inner.next_ref_mut()
+        self.inner.next().map(|p| unsafe { &mut *p })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -467,7 +447,7 @@ impl<'a, A, D: Dimension> Iterator for ElementsBaseMut<'a, A, D> {
 impl<'a, A> DoubleEndedIterator for ElementsBaseMut<'a, A, Ix1> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a mut A> {
-        self.inner.next_back_ref_mut()
+        self.inner.next_back().map(|p| unsafe { &mut *p })
     }
 }
 
@@ -488,9 +468,9 @@ impl<'a, A, D: Dimension> Iterator for IndexedIterMut<'a, A, D> {
             None => return None,
             Some(ref ix) => ix.clone(),
         };
-        match self.0.inner.next_ref_mut() {
+        match self.0.next() {
             None => None,
-            Some(p) => Some((index.into_pattern(), p)),
+            Some(elem) => Some((index.into_pattern(), elem)),
         }
     }
 

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -29,10 +29,7 @@ use super::{
     NdProducer,
 };
 
-pub use self::windows::{
-    Windows,
-    windows
-};
+pub use self::windows::Windows;
 pub use self::chunks::{
     ExactChunks,
     ExactChunksIter,

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -515,6 +515,18 @@ pub struct LanesIter<'a, A: 'a, D> {
     life: PhantomData<&'a A>,
 }
 
+clone_bounds!(
+    ['a, A, D: Clone]
+    LanesIter['a, A, D] {
+        @copy {
+            inner_len,
+            inner_stride,
+            life,
+        }
+        iter,
+    }
+);
+
 impl<'a, A, D> Iterator for LanesIter<'a, A, D>
     where D: Dimension
 {

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -704,6 +704,18 @@ clone_bounds!(
     }
 );
 
+impl<'a, A, D: Dimension> AxisIter<'a, A, D> {
+    /// Creates a new iterator over the specified axis.
+    pub(crate) fn new<Di>(v: ArrayView<'a, A, Di>, axis: Axis) -> Self
+    where
+        Di: RemoveAxis<Smaller = D>,
+    {
+        AxisIter {
+            iter: AxisIterCore::new(v, axis),
+            life: PhantomData,
+        }
+    }
+}
 
 macro_rules! axis_iter_split_at_impl {
     ($iter: ident) => (
@@ -791,26 +803,6 @@ impl<'a, A, D> ExactSizeIterator for AxisIter<'a, A, D>
     }
 }
 
-pub fn new_outer_iter<A, D>(v: ArrayView<A, D>) -> AxisIter<A, D::Smaller>
-    where D: RemoveAxis
-{
-    AxisIter {
-        iter: AxisIterCore::new(v, Axis(0)),
-        life: PhantomData,
-    }
-}
-
-pub fn new_axis_iter<A, D>(v: ArrayView<A, D>, axis: usize)
-    -> AxisIter<A, D::Smaller>
-    where D: RemoveAxis
-{
-    AxisIter {
-        iter: AxisIterCore::new(v, Axis(axis)),
-        life: PhantomData,
-    }
-}
-
-
 /// An iterator that traverses over an axis and
 /// and yields each subview (mutable)
 ///
@@ -828,6 +820,19 @@ pub fn new_axis_iter<A, D>(v: ArrayView<A, D>, axis: usize)
 pub struct AxisIterMut<'a, A: 'a, D> {
     iter: AxisIterCore<A, D>,
     life: PhantomData<&'a mut A>,
+}
+
+impl<'a, A, D: Dimension> AxisIterMut<'a, A, D> {
+    /// Creates a new iterator over the specified axis.
+    pub(crate) fn new<Di>(v: ArrayViewMut<'a, A, Di>, axis: Axis) -> Self
+    where
+        Di: RemoveAxis<Smaller = D>,
+    {
+        AxisIterMut {
+            iter: AxisIterCore::new(v, axis),
+            life: PhantomData,
+        }
+    }
 }
 
 axis_iter_split_at_impl!(AxisIterMut);
@@ -867,25 +872,6 @@ impl<'a, A, D> ExactSizeIterator for AxisIterMut<'a, A, D>
 {
     fn len(&self) -> usize {
         self.size_hint().0
-    }
-}
-
-pub fn new_outer_iter_mut<A, D>(v: ArrayViewMut<A, D>) -> AxisIterMut<A, D::Smaller>
-    where D: RemoveAxis
-{
-    AxisIterMut {
-        iter: AxisIterCore::new(v, Axis(0)),
-        life: PhantomData,
-    }
-}
-
-pub fn new_axis_iter_mut<A, D>(v: ArrayViewMut<A, D>, axis: usize)
-    -> AxisIterMut<A, D::Smaller>
-    where D: RemoveAxis
-{
-    AxisIterMut {
-        iter: AxisIterCore::new(v, Axis(axis)),
-        life: PhantomData,
     }
 }
 

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -737,36 +737,24 @@ impl<'a, A, D: Dimension> AxisIter<'a, A, D> {
             life: PhantomData,
         }
     }
-}
 
-macro_rules! axis_iter_split_at_impl {
-    ($iter: ident) => (
-        impl<'a, A, D> $iter<'a, A, D>
-            where D: Dimension
-        {
-            /// Split the iterator at index, yielding two disjoint iterators.
-            ///
-            /// *panics* if `index` is strictly greater than the iterator's length
-            pub fn split_at(self, index: Ix)
-                -> ($iter<'a, A, D>, $iter<'a, A, D>)
-            {
-                let (left, right) = self.iter.split_at(index);
-                (
-                    $iter {
-                        iter: left,
-                        life: self.life,
-                    },
-                    $iter {
-                        iter: right,
-                        life: self.life,
-                    },
-                )
-            }
-        }
-    )
+    /// Split the iterator at index, yielding two disjoint iterators.
+    ///
+    /// **Panics** if `index` is strictly greater than the iterator's length
+    pub fn split_at(self, index: usize) -> (Self, Self) {
+        let (left, right) = self.iter.split_at(index);
+        (
+            AxisIter {
+                iter: left,
+                life: self.life,
+            },
+            AxisIter {
+                iter: right,
+                life: self.life,
+            },
+        )
+    }
 }
-
-axis_iter_split_at_impl!(AxisIter);
 
 impl<'a, A, D> Iterator for AxisIter<'a, A, D>
     where D: Dimension
@@ -836,9 +824,24 @@ impl<'a, A, D: Dimension> AxisIterMut<'a, A, D> {
             life: PhantomData,
         }
     }
-}
 
-axis_iter_split_at_impl!(AxisIterMut);
+    /// Split the iterator at index, yielding two disjoint iterators.
+    ///
+    /// **Panics** if `index` is strictly greater than the iterator's length
+    pub fn split_at(self, index: usize) -> (Self, Self) {
+        let (left, right) = self.iter.split_at(index);
+        (
+            AxisIterMut {
+                iter: left,
+                life: self.life,
+            },
+            AxisIterMut {
+                iter: right,
+                life: self.life,
+            },
+        )
+    }
+}
 
 impl<'a, A, D> Iterator for AxisIterMut<'a, A, D>
     where D: Dimension

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -42,8 +42,6 @@ pub use self::chunks::{
     exact_chunks_mut_of,
 };
 pub use self::lanes::{
-    new_lanes,
-    new_lanes_mut,
     Lanes,
     LanesMut,
 };

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -33,10 +33,8 @@ pub use self::windows::Windows;
 pub use self::chunks::{
     ExactChunks,
     ExactChunksIter,
-    exact_chunks_of,
     ExactChunksMut,
     ExactChunksIterMut,
-    exact_chunks_mut_of,
 };
 pub use self::lanes::{
     Lanes,

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -504,8 +504,8 @@ impl<'a, A, D> ExactSizeIterator for IndexedIterMut<'a, A, D>
     }
 }
 
-/// An iterator that traverses over all dimensions but the innermost,
-/// and yields each inner row.
+/// An iterator that traverses over all axes but one, and yields a view for
+/// each lane along that axis.
 ///
 /// See [`.lanes()`](../struct.ArrayBase.html#method.lanes) for more information.
 pub struct LanesIter<'a, A: 'a, D> {

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -991,9 +991,10 @@ clone_bounds!(
     }
 );
 
-fn chunk_iter_parts<A, D: Dimension>(v: ArrayView<A, D>, axis: usize, size: usize)
+fn chunk_iter_parts<A, D: Dimension>(v: ArrayView<A, D>, axis: Axis, size: usize)
     -> (AxisIterCore<A, D>, *mut A, D)
 {
+    let axis = axis.index();
     let axis_len = v.shape()[axis];
     let size = if size > axis_len { axis_len } else { size };
     let last_index = axis_len / size;
@@ -1027,17 +1028,15 @@ fn chunk_iter_parts<A, D: Dimension>(v: ArrayView<A, D>, axis: usize, size: usiz
     (iter, last_ptr, last_dim)
 }
 
-pub fn new_chunk_iter<A, D>(v: ArrayView<A, D>, axis: usize, size: usize)
-    -> AxisChunksIter<A, D>
-    where D: Dimension
-{
-    let (iter, last_ptr, last_dim) = chunk_iter_parts(v, axis, size);
-
-    AxisChunksIter {
-        iter: iter,
-        last_ptr: last_ptr,
-        last_dim: last_dim,
-        life: PhantomData,
+impl<'a, A, D: Dimension> AxisChunksIter<'a, A, D> {
+    pub(crate) fn new(v: ArrayView<'a, A, D>, axis: Axis, size: usize) -> Self {
+        let (iter, last_ptr, last_dim) = chunk_iter_parts(v, axis, size);
+        AxisChunksIter {
+            iter: iter,
+            last_ptr: last_ptr,
+            last_dim: last_dim,
+            life: PhantomData,
+        }
     }
 }
 
@@ -1116,17 +1115,15 @@ pub struct AxisChunksIterMut<'a, A: 'a, D> {
     life: PhantomData<&'a mut A>,
 }
 
-pub fn new_chunk_iter_mut<A, D>(v: ArrayViewMut<A, D>, axis: usize, size: usize)
-    -> AxisChunksIterMut<A, D>
-    where D: Dimension
-{
-    let (iter, last_ptr, last_dim) = chunk_iter_parts(v.into_view(), axis, size);
-
-    AxisChunksIterMut {
-        iter: iter,
-        last_ptr: last_ptr,
-        last_dim: last_dim,
-        life: PhantomData,
+impl<'a, A, D: Dimension> AxisChunksIterMut<'a, A, D> {
+    pub(crate) fn new(v: ArrayViewMut<'a, A, D>, axis: Axis, size: usize) -> Self {
+        let (iter, last_ptr, last_dim) = chunk_iter_parts(v.into_view(), axis, size);
+        AxisChunksIterMut {
+            iter: iter,
+            last_ptr: last_ptr,
+            last_dim: last_dim,
+            life: PhantomData,
+        }
     }
 }
 

--- a/src/iterators/windows.rs
+++ b/src/iterators/windows.rs
@@ -15,30 +15,31 @@ pub struct Windows<'a, A: 'a, D> {
     strides: D,
 }
 
-pub fn windows<A, D, E>(a: ArrayView<A, D>, window_size: E) -> Windows<A, D>
-	where D: Dimension,
-          E: IntoDimension<Dim=D>,
-{
-    let window = window_size.into_dimension();
-    ndassert!(a.ndim() == window.ndim(),
-        concat!("Window dimension {} does not match array dimension {} ",
-        "(with array of shape {:?})"),
-        window.ndim(), a.ndim(), a.shape());
-    let mut size = a.dim;
-    for (sz, &ws) in size.slice_mut().iter_mut().zip(window.slice())
+impl<'a, A, D: Dimension> Windows<'a, A, D> {
+    pub(crate) fn new<E>(a: ArrayView<'a, A, D>, window_size: E) -> Self
+    where
+        E: IntoDimension<Dim = D>,
     {
-        if ws == 0 { panic!("window-size must not be zero!"); }
-        // cannot use std::cmp::max(0, ..) since arithmetic underflow panics
-        *sz = if *sz < ws { 0 } else { *sz - ws + 1 };
-    }
+        let window = window_size.into_dimension();
+        ndassert!(a.ndim() == window.ndim(),
+            concat!("Window dimension {} does not match array dimension {} ",
+            "(with array of shape {:?})"),
+            window.ndim(), a.ndim(), a.shape());
+        let mut size = a.dim;
+        for (sz, &ws) in size.slice_mut().iter_mut().zip(window.slice()) {
+            assert_ne!(ws, 0, "window-size must not be zero!");
+            // cannot use std::cmp::max(0, ..) since arithmetic underflow panics
+            *sz = if *sz < ws { 0 } else { *sz - ws + 1 };
+        }
 
-    let window_strides = a.strides.clone();
+        let window_strides = a.strides.clone();
 
-    unsafe {
-        Windows {
-            base: ArrayView::from_shape_ptr(size.clone().strides(a.strides), a.ptr),
-            window: window,
-            strides: window_strides,
+        unsafe {
+            Windows {
+                base: ArrayView::from_shape_ptr(size.clone().strides(a.strides), a.ptr),
+                window: window,
+                strides: window_strides,
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ pub use error::{ShapeError, ErrorKind};
 pub use slice::{Slice, SliceInfo, SliceNextDim, SliceOrIndex};
 
 use iterators::Baseiter;
-use iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut};
+use iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut, Lanes, LanesMut};
 
 pub use arraytraits::AsArray;
 pub use linalg_traits::{LinalgScalar, NdFloat};
@@ -877,7 +877,7 @@ impl<A, S, D> ArrayBase<S, D>
     fn inner_rows(&self) -> iterators::Lanes<A, D::Smaller>
     {
         let n = self.ndim();
-        iterators::new_lanes(self.view(), Axis(n.saturating_sub(1)))
+        Lanes::new(self.view(), Axis(n.saturating_sub(1)))
     }
 
     /// n-d generalization of rows, just like inner iter
@@ -885,7 +885,7 @@ impl<A, S, D> ArrayBase<S, D>
         where S: DataMut
     {
         let n = self.ndim();
-        iterators::new_lanes_mut(self.view_mut(), Axis(n.saturating_sub(1)))
+        LanesMut::new(self.view_mut(), Axis(n.saturating_sub(1)))
     }
 }
 


### PR DESCRIPTION
This PR does the following:

* Removes lots of iterator constructor functions and replaces them with `new` methods on the iterators. This is more conventional, easier to understand, and requires fewer imports.

* Renames `OuterIterCore` to `AxisIterCore` to better reflect its purpose.

* Refactors `.split_at()` for `AxisIter` and `AxisIterMut` to eliminate the `axis_iter_split_at_impl!` macro.

* Removes the lifetime from `Baseiter` and implements iterator traits for `Baseiter`. This is mostly a conceptual simplification. It will also make it more straightforward to extend the iterators to `ArrayPtr`/`ArrayPtrMut` in #496.

* Improve docs and implement `Clone` for `LanesIter`.