### PR TITLE
Panic on remove_axis if length of axis is zero

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1512,10 +1512,12 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     }
 
     /// Remove array axis `axis` and return the result.
+    ///
+    /// **Panics** if the axis is out of bounds or its length is zero.
     pub fn remove_axis(self, axis: Axis) -> ArrayBase<S, D::Smaller>
         where D: RemoveAxis,
     {
-        assert!(self.ndim() != 0);
+        assert_ne!(self.len_of(axis), 0, "Length of removed axis must be nonzero.");
         let d = self.dim.remove_axis(axis);
         let s = self.strides.remove_axis(axis);
         ArrayBase {


### PR DESCRIPTION
Before, this would print uninitialized values:

```rust
use ndarray::prelude::*;

let v = ArrayView2::<i32>::from_shape((0, 2), &[]).unwrap();
println!("{:?}", v.remove_axis(Axis(0)));
```

Now, it panics.